### PR TITLE
Remove status field on share network detail page

### DIFF
--- a/openstack_dashboard/dashboards/project/shares/templates/shares/share_networks/_detail_overview.html
+++ b/openstack_dashboard/dashboards/project/shares/templates/shares/share_networks/_detail_overview.html
@@ -15,8 +15,6 @@
     <dt>{% trans "Description" %}</dt>
     <dd>{{ share_network.description }}</dd>
     {% endif %}
-    <dt>{% trans "Status" %}</dt>
-    <dd>{{ share_network.status|capfirst }}</dd>
     {% if share_network.share_servers %}
     <dt>{% trans "Share Servers on this network" %}</dt>
     {% for server in share_network.share_servers %}


### PR DESCRIPTION
Remove displaying of "status" field on share-network detail page
because this field is absent in share-network model.
