### PR TITLE
Add link to source share on snapshot detail page

### DIFF
--- a/openstack_dashboard/dashboards/project/shares/snapshots/views.py
+++ b/openstack_dashboard/dashboards/project/shares/snapshots/views.py
@@ -53,6 +53,8 @@ class SnapshotDetailView(tabs.TabView):
         try:
             snapshot_id = self.kwargs['snapshot_id']
             snapshot = manila.share_snapshot_get(self.request, snapshot_id)
+            share = manila.share_get(self.request, snapshot.share_id)
+            snapshot.share_name_or_id = share.name or share.id
         except Exception:
             redirect = reverse('horizon:project:shares:index')
             exceptions.handle(self.request,

--- a/openstack_dashboard/dashboards/project/shares/templates/shares/snapshots/_snapshot_detail_overview.html
+++ b/openstack_dashboard/dashboards/project/shares/templates/shares/snapshots/_snapshot_detail_overview.html
@@ -11,8 +11,9 @@
     <dd>{{ snapshot.name }}</dd>
     <dt>{% trans "ID" %}</dt>
     <dd>{{ snapshot.id }}</dd>
+    {% url 'horizon:admin:shares:detail' snapshot.share_id as share_url %}
     <dt>{% trans "Source" %}</dt>
-    <dd>{{ snapshot.share_id }}</dd>
+    <dd><a href="{{ share_url }}">{{ snapshot.share_name_or_id }}</a></dd>
     {% if snapshot.description %}
     <dt>{% trans "Description" %}</dt>
     <dd>{{ snapshot.description }}</dd>


### PR DESCRIPTION
Link to source share on detail page of snapshot was absent. Add it, using at first name, if exists or id if name does not exist.
